### PR TITLE
create method to get png byte data of entire table

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -146,6 +146,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  screenshot:
+    dependency: transitive
+    description:
+      name: screenshot
+      sha256: "63817697a7835e6ce82add4228e15d233b74d42975c143ad8cfe07009fab866b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/lib/src/dashboard.dart
+++ b/lib/src/dashboard.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:dashboard_grid/src/table/table_span.dart';
 import 'package:flutter/material.dart';
 
@@ -8,6 +10,7 @@ import 'dashboard_widget.dart';
 import 'table/table.dart';
 import 'table/table_cell.dart';
 import 'table/table_cell_decoration.dart';
+import 'package:screenshot/screenshot.dart';
 
 class Dashboard extends StatefulWidget {
   const Dashboard({
@@ -15,11 +18,13 @@ class Dashboard extends StatefulWidget {
     this.editMode = false,
     required this.config,
     this.cellPreviewDecoration = const TableCellDecoration(),
+    this.controller,
   });
 
   final bool editMode;
   final DashboardGrid config;
   final TableCellDecoration cellPreviewDecoration;
+  final DashboardController? controller;
 
   @override
   State<Dashboard> createState() => _DashboardState();
@@ -30,12 +35,14 @@ class _DashboardState extends State<Dashboard> {
   final xController = ScrollController();
 
   DashboardGrid? originalConfig;
+  ScreenshotController screenshotController = ScreenshotController();
 
   @override
   void initState() {
     widget.config.addListener(_configListener);
 
     super.initState();
+    widget.controller?._attach(this);
   }
 
   @override
@@ -50,6 +57,29 @@ class _DashboardState extends State<Dashboard> {
   void _configListener() {
     setState(() {});
   }
+
+  Future<Uint8List?> getPngBytes(BuildContext context) async {
+    // Calculate the dynamic size based on the dashboard configuration
+    final double totalWidth = widget.config.maxColumns * kWidgetWidth +
+        (widget.config.maxColumns - 1) * kWidgetSpacing;
+    final double totalHeight = widget.config.currentHeight * kWidgetHeight +
+        (widget.config.currentHeight - 1) * kWidgetSpacing;
+
+    return await screenshotController.captureFromWidget(
+      Overlay(
+        initialEntries: [
+          OverlayEntry(
+            builder: (context) => _buildLongDashboard(context),
+          ),
+        ],
+      ),
+      context: context,
+      targetSize: Size(totalWidth + 35, totalHeight + 35), // extra added for padding
+      delay: const Duration(milliseconds: 100),
+      pixelRatio: 2.0,
+    );
+  }
+
 
   @override
   void didUpdateWidget(covariant Dashboard oldWidget) {
@@ -77,6 +107,101 @@ class _DashboardState extends State<Dashboard> {
 
   @override
   Widget build(BuildContext context) {
+    return _buildDashboard(context);
+  }
+
+  TableViewCell? _findBestCellMatch(TableVicinity vicinity) {
+    final config = widget.config.getWidgetAt(vicinity.xIndex, vicinity.yIndex);
+    if (config == null) return null;
+
+    BoxConstraints constraints = BoxConstraints.expand(
+      width: kWidgetWidth * config.width + kWidgetSpacing * (config.width - 1),
+      height:
+      kWidgetHeight * config.height + kWidgetSpacing * (config.height - 1),
+    );
+
+    final child =
+    widget.editMode
+        ? Draggable(
+      data: config,
+      feedback: Opacity(
+        opacity: 0.5,
+        child: ConstrainedBox(
+          constraints: constraints,
+          child: config.builder(context),
+        ),
+      ),
+      childWhenDragging: Container(),
+      child: DragTarget<DashboardWidget>(
+        builder: (context, candidate, rejected) {
+          return config.builder(context);
+        },
+        onAcceptWithDetails: (details) {
+          try {
+            widget.config.moveWidget(
+              details.data.id,
+              vicinity.xIndex,
+              vicinity.yIndex,
+            );
+          } on NotEnoughSpaceException {
+            // Oops
+          } catch (e) {
+            rethrow;
+          }
+
+          setState(() {});
+        },
+      ),
+      onDragUpdate: (details) {
+        // Update details
+        // print(details.localPosition);
+      },
+    )
+        : config.builder(context);
+
+    return TableViewCell(
+      columnMergeStart: config.x,
+      columnMergeSpan: config.width,
+      child: child,
+    );
+  }
+
+  TableSpan _buildColumnSpan(int index) {
+    return TableSpan(
+      // backgroundDecoration:
+      //     widget.editMode
+      //         ? SpanDecoration(
+      //           color: Colors.red.withAlpha(100),
+      //           consumeSpanPadding: false,
+      //         )
+      //         : null,
+      padding: SpanPadding(
+        leading: kWidgetSpacing,
+        trailing: widget.config.maxColumns - 1 == index ? kWidgetSpacing : 0.0,
+      ),
+      extent: const FixedTableSpanExtent(kWidgetWidth),
+    );
+  }
+
+  TableSpan _buildRowSpan(int index) {
+    return TableSpan(
+      padding: SpanPadding(
+        leading: kWidgetSpacing,
+        trailing:
+        widget.config.currentHeight - 1 == index ? kWidgetSpacing : 0.0,
+      ),
+      // backgroundDecoration:
+      //     widget.editMode
+      //         ? SpanDecoration(
+      //           color: Colors.green.withAlpha(100),
+      //           consumeSpanPadding: false,
+      //         )
+      //         : null,
+      extent: const FixedTableSpanExtent(kWidgetHeight),
+    );
+  }
+
+  Widget _buildDashboard(BuildContext context) {
     return Scrollbar(
       trackVisibility: true,
       thumbVisibility: true,
@@ -137,94 +262,25 @@ class _DashboardState extends State<Dashboard> {
     );
   }
 
-  TableViewCell? _findBestCellMatch(TableVicinity vicinity) {
-    final config = widget.config.getWidgetAt(vicinity.xIndex, vicinity.yIndex);
-    if (config == null) return null;
-
-    BoxConstraints constraints = BoxConstraints.expand(
-      width: kWidgetWidth * config.width + kWidgetSpacing * (config.width - 1),
-      height:
-          kWidgetHeight * config.height + kWidgetSpacing * (config.height - 1),
-    );
-
-    final child =
-        widget.editMode
-            ? Draggable(
-              data: config,
-              feedback: Opacity(
-                opacity: 0.5,
-                child: ConstrainedBox(
-                  constraints: constraints,
-                  child: config.builder(context),
-                ),
-              ),
-              childWhenDragging: Container(),
-              child: DragTarget<DashboardWidget>(
-                builder: (context, candidate, rejected) {
-                  return config.builder(context);
-                },
-                onAcceptWithDetails: (details) {
-                  try {
-                    widget.config.moveWidget(
-                      details.data.id,
-                      vicinity.xIndex,
-                      vicinity.yIndex,
-                    );
-                  } on NotEnoughSpaceException {
-                    // Oops
-                  } catch (e) {
-                    rethrow;
-                  }
-
-                  setState(() {});
-                },
-              ),
-              onDragUpdate: (details) {
-                // Update details
-                // print(details.localPosition);
-              },
-            )
-            : config.builder(context);
-
-    return TableViewCell(
-      columnMergeStart: config.x,
-      columnMergeSpan: config.width,
-      child: child,
+  Widget _buildLongDashboard(BuildContext context) {
+    return Material(
+      child: InheritedTheme.captureAll(
+        context,
+        _buildDashboard(context),
+      ),
     );
   }
 
-  TableSpan _buildColumnSpan(int index) {
-    return TableSpan(
-      // backgroundDecoration:
-      //     widget.editMode
-      //         ? SpanDecoration(
-      //           color: Colors.red.withAlpha(100),
-      //           consumeSpanPadding: false,
-      //         )
-      //         : null,
-      padding: SpanPadding(
-        leading: kWidgetSpacing,
-        trailing: widget.config.maxColumns - 1 == index ? kWidgetSpacing : 0.0,
-      ),
-      extent: const FixedTableSpanExtent(kWidgetWidth),
-    );
+}
+
+class DashboardController {
+  late _DashboardState _state;
+
+  void _attach(_DashboardState state) {
+    _state = state;
   }
 
-  TableSpan _buildRowSpan(int index) {
-    return TableSpan(
-      padding: SpanPadding(
-        leading: kWidgetSpacing,
-        trailing:
-            widget.config.currentHeight - 1 == index ? kWidgetSpacing : 0.0,
-      ),
-      // backgroundDecoration:
-      //     widget.editMode
-      //         ? SpanDecoration(
-      //           color: Colors.green.withAlpha(100),
-      //           consumeSpanPadding: false,
-      //         )
-      //         : null,
-      extent: const FixedTableSpanExtent(kWidgetHeight),
-    );
+  Future<Uint8List?> getPngBytes(BuildContext context) async {
+    return _state.getPngBytes(context);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   flutter:
     sdk: flutter
   collection: ^1.19.1
+  screenshot: ^3.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
@nonameden TLDR: I've added this here because it's the best way (as far as I can tell) to export the entire dashboard as a PNG. 

Long explanation:
Because of how flutter renders/paints things to the screen it's very difficult to export images of large widgets that require scrollbars. This method solves that issue. And because I can't easily access the state of the Dashboard table externally from this package, the easiest way was to add a method that exposes a screenshot method internally.

I'd also like to add another method that exports a list of PNG byte data of each individual table cell in the future if it's ok.