### PR TITLE
Fix: Use env context instead of secrets in GitHub Actions if condition

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ jobs:
   sonarqube:
     name: SonarQube
     runs-on: ubuntu-latest
+    env:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -23,7 +25,7 @@ jobs:
             flutter pub get
             flutter test --machine --coverage > tests.output
       - name: SonarQube Scan
-        if: ${{ secrets.SONAR_TOKEN != '' }}
+        if: ${{ env.SONAR_TOKEN != '' }}
         uses: SonarSource/sonarqube-scan-action@v6
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,4 +29,3 @@ jobs:
         uses: SonarSource/sonarqube-scan-action@v6
         env:
           SONAR_TOKEN: ${{ env.SONAR_TOKEN }}
-          SONAR_HOST_URL: https://sonarcloud.io

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,4 +28,5 @@ jobs:
         if: ${{ env.SONAR_TOKEN != '' }}
         uses: SonarSource/sonarqube-scan-action@v6
         env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_TOKEN: ${{ env.SONAR_TOKEN }}
+          SONAR_HOST_URL: https://sonarcloud.io

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,3 +4,4 @@ sonar.sources=lib/
 sonar.tests=test/
 sonar.exclusions=test/**/*_test.mocks.dart,lib/**/*.g.dart
 sonar.dart.lcov.reportPaths=coverage/lcov.info
+sonar.host.url=https://sonarcloud.io


### PR DESCRIPTION
Fix: Use env context instead of secrets in GitHub Actions if condition

GitHub Actions workflows do not allow the `secrets` context to be accessed directly in an `if` conditional, which results in an "Unrecognized named-value: 'secrets'" error. This commit resolves the issue by exporting the `SONAR_TOKEN` secret as a job-level environment variable and referencing `env.SONAR_TOKEN` in the `if` conditional.

---
*PR created automatically by Jules for task [110630777873082844](https://jules.google.com/task/110630777873082844) started by @nonameden*