### PR TITLE
⚡ Optimize O(N^2) list difference calculation

### DIFF
--- a/lib/src/dashboard_grid.dart
+++ b/lib/src/dashboard_grid.dart
@@ -216,8 +216,11 @@ class DashboardGrid with ChangeNotifier {
     List<DashboardWidget> from,
     List<DashboardWidget> to,
   ) {
+    final fromMap = {for (final w in from) w.id: w};
+    final toMap = {for (final w in to) w.id: w};
+
     final addedWidgets = to.map((toWidget) {
-      final isNew = !from.any((fromWidget) => fromWidget.id == toWidget.id);
+      final isNew = !fromMap.containsKey(toWidget.id);
       if (isNew) {
         return DashboardGridChangeSnapshot(from: null, to: toWidget);
       }
@@ -226,7 +229,7 @@ class DashboardGrid with ChangeNotifier {
     });
 
     final removedWidgets = from.map((fromWidget) {
-      final isRemoved = !to.any((toWidget) => toWidget.id == fromWidget.id);
+      final isRemoved = !toMap.containsKey(fromWidget.id);
       if (isRemoved) {
         return DashboardGridChangeSnapshot(from: fromWidget, to: null);
       }
@@ -235,9 +238,7 @@ class DashboardGrid with ChangeNotifier {
     });
 
     final movedWidgets = from.map((fromWidget) {
-      final toWidget = to.firstWhereOrNull(
-        (toWidget) => toWidget.id == fromWidget.id,
-      );
+      final toWidget = toMap[fromWidget.id];
       final hasMoved =
           toWidget != null &&
           (fromWidget.x != toWidget.x || fromWidget.y != toWidget.y);


### PR DESCRIPTION
Optimized the widget difference calculation in `DashboardGrid` to improve performance.

💡 **What:** The optimization replaces nested linear searches (`any`, `firstWhereOrNull`) with hash map lookups in the `_findDifference` method.
🎯 **Why:** The previous implementation had $O(N^2)$ complexity, which caused performance degradation as the number of widgets in the dashboard increased.
📊 **Measured Improvement:** The complexity was reduced from $O(N \cdot M)$ to $O(N + M)$. Logic verification confirmed that the optimized approach correctly identifies added, removed, and moved widgets. Standard test suite execution was hindered by environment timeouts, but core logic was validated through a standalone script.

---
*PR created automatically by Jules for task [3314809582774936](https://jules.google.com/task/3314809582774936) started by @nonameden*