### PR TITLE
🧪 test: add coverage for general exception on widget move

### DIFF
--- a/test/dashboard_grid_widget_test.dart
+++ b/test/dashboard_grid_widget_test.dart
@@ -2,6 +2,15 @@ import 'package:dashboard_grid/dashboard_grid.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+class MockDashboardGrid extends DashboardGrid {
+  MockDashboardGrid({required super.maxColumns});
+
+  @override
+  void moveWidget(String id, {required int x, required int y}) {
+    throw Exception('General Exception');
+  }
+}
+
 void main() {
   testWidgets('should be able to display empty dashboard', (tester) async {
     // Arrange
@@ -76,5 +85,43 @@ void main() {
     // Assert
     expect(find.byType(Dashboard), findsOneWidget);
     expect(find.text('Widget 1'), findsOneWidget);
+  });
+
+  testWidgets('throws general exception on widget move', (tester) async {
+    final config = MockDashboardGrid(maxColumns: 2);
+    config.addWidget(
+      DashboardWidget(
+        id: 'id1',
+        x: 0,
+        y: 0,
+        width: 1,
+        height: 1,
+        builder: (context) {
+          return Container(color: Colors.red, child: Text('Widget 1'));
+        },
+      ),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: Dashboard(config: config, editMode: true)),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.text('Widget 1')),
+    );
+    await tester.pump(const Duration(milliseconds: 500)); // long press for drag
+    await gesture.moveTo(
+      tester.getCenter(find.byType(DragTarget<DashboardWidget>).last),
+    );
+    await tester.pump();
+
+    // Expecting exception
+    await gesture.up();
+    await tester.pump();
+
+    expect(tester.takeException(), isA<Exception>());
   });
 }


### PR DESCRIPTION
🎯 **What:** Adds a test for the general exception catch block in `_onDrop` for `moveWidget` within `Dashboard`.
📊 **Coverage:** Now asserts that the exception rethrowing is fully covered.
✨ **Result:** Improved robustness by asserting generic failures in grid moves are handled via `rethrow`.

---
*PR created automatically by Jules for task [4319151105089221599](https://jules.google.com/task/4319151105089221599) started by @nonameden*