### PR TITLE
🧪 testing improvement: add missing edge case test for DashboardGridChangeSnapshot

### DIFF
--- a/test/dashboard_grid_test.dart
+++ b/test/dashboard_grid_test.dart
@@ -271,4 +271,10 @@ void main() {
     expect(result!.x, 1);
     expect(result.y, 1);
   });
+  test('DashboardGridChangeSnapshot with both from and to as null should throw AssertionError', () {
+    expect(
+      () => DashboardGridChangeSnapshot(from: null, to: null),
+      throwsA(isA<AssertionError>()),
+    );
+  });
 }


### PR DESCRIPTION
🎯 **What:** Added a missing edge case test for `DashboardGridChangeSnapshot` to ensure an `AssertionError` is thrown when both `from` and `to` are `null`.
📊 **Coverage:** The test now covers the initialization edge case for `DashboardGridChangeSnapshot`.
✨ **Result:** Increased test coverage and confidence in the expected behavior of `DashboardGridChangeSnapshot`.

---
*PR created automatically by Jules for task [1533469270128598377](https://jules.google.com/task/1533469270128598377) started by @nonameden*