### PR TITLE
fix(ci): Ensure DevTools extension builds and is published to pub.dev

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -35,6 +35,13 @@ jobs:
       - name: Run tests
         run: flutter test
 
+      - name: Build DevTools extension
+        run: |
+          cd dashboard_grid_devtools_extension
+          flutter pub get
+          dart run devtools_extensions build_and_copy --source=. --dest=../extension/devtools
+          cd ..
+
       - name: Generate changelog from commit messages
         id: changelog
         run: |
@@ -66,10 +73,9 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git add pubspec.yaml CHANGELOG.md
+          git add pubspec.yaml CHANGELOG.md extension/devtools/build
           git commit -m "chore: Release v${{ github.event.inputs.version }}"
           git tag -a "v${{ github.event.inputs.version }}" -m "Release v${{ github.event.inputs.version }}"
-
       - name: Push changes
         run: |
           git push origin HEAD:${{ github.ref_name }}
@@ -83,6 +89,7 @@ jobs:
           body: ${{ env.CHANGELOG_CONTENT }}
           draft: false
           prerelease: false
+
 
       - name: Setup Dart for pub.dev
         uses: dart-lang/setup-dart@v1

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ migrate_working_dir/
 .flutter-plugins
 .flutter-plugins-dependencies
 build/
+
+# Let's include the built devtools extension, pub publish needs it
+!extension/devtools/build/

--- a/.pubignore
+++ b/.pubignore
@@ -1,0 +1,14 @@
+# Exclude test files
+test/
+integration_test/
+
+# Exclude coverage output
+coverage/
+
+# Exclude unneeded assets
+example/
+dashboard_grid_devtools_extension/
+benchmark.dart
+
+# But MAKE SURE we include devtools build
+!extension/devtools/build/

--- a/dashboard_grid_devtools_extension/pubspec.lock
+++ b/dashboard_grid_devtools_extension/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -252,26 +252,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -393,10 +393,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.9"
   typed_data:
     dependency: transitive
     description:
@@ -542,5 +542,5 @@ packages:
     source: hosted
     version: "2.2.2"
 sdks:
-  dart: ">=3.8.0 <4.0.0"
+  dart: ">=3.9.0-0 <4.0.0"
   flutter: ">=3.27.1"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -55,7 +55,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.6"
+    version: "0.0.7"
   fake_async:
     dependency: transitive
     description:


### PR DESCRIPTION
The CI pipeline for publishing to pub.dev was failing because the devtools extension wasn't being built, and its output directory was ignored.

- Updated create-release.yml workflow to build devtools before publishing.
- Added a step to run build_and_copy script in dashboard_grid_devtools_extension.
- Included extension/devtools/build in the workflow git commit for the tag.
- Un-ignored the devtools build directory in .gitignore and .pubignore so pub publish will include it.
- Explicitly ignored unnecessary test files and sub-packages in .pubignore for a clean publish payload.

---
*PR created automatically by Jules for task [9513529818244465201](https://jules.google.com/task/9513529818244465201) started by @nonameden*